### PR TITLE
Update OLEDDisplay.cpp

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -51,6 +51,7 @@ OLEDDisplay::OLEDDisplay() {
 #ifdef OLEDDISPLAY_DOUBLE_BUFFER
 	buffer_back = NULL;
 #endif
+  logBuffer = NULL;
 }
 
 OLEDDisplay::~OLEDDisplay() {
@@ -63,7 +64,6 @@ bool OLEDDisplay::allocateBuffer() {
   logBufferFilled = 0;
   logBufferLine = 0;
   logBufferMaxLines = 0;
-  logBuffer = NULL;
 
   if (!this->connect()) {
     DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Can't establish connection to display\n");


### PR DESCRIPTION
shift assignment of logBuffer = NULL to constructor

currently, in the constructor, buffer and buffer_back are set to NULL, but not for logBuffer (this is not consistent and may lead to failures if class is deconstructed without having called init() as address of logBuffer is not defined properly